### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,8 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux-64
-            smoke-test: false
           - os: macos-latest
             platform: osx-arm64
-            smoke-test: true
 
     runs-on: ${{ matrix.os }}
 
@@ -50,34 +48,5 @@ jobs:
           log-level: v
           cache: true
 
-      - name: Run test (full)
-        if: ${{ !matrix.smoke-test }}
+      - name: Run test
         run: pixi run test
-
-      - name: Run test (2min timeout)
-        if: ${{ matrix.smoke-test }}
-        run: |
-          # Start the test in the background
-          pixi run test &
-          TEST_PID=$!
-
-          # Wait for 2 minutes
-          sleep 120
-
-          # Check if the process is still running
-          if kill -0 $TEST_PID 2>/dev/null; then
-            echo "Test still running after 2 minutes - stopping"
-            kill $TEST_PID 2>/dev/null || true
-            exit 0
-          else
-            # Process finished - check if it succeeded or failed
-            wait $TEST_PID
-            EXIT_CODE=$?
-            if [ $EXIT_CODE -eq 0 ]; then
-              echo "Test completed successfully within 2 minutes"
-              exit 0
-            else
-              echo "Test failed with exit code $EXIT_CODE"
-              exit $EXIT_CODE
-            fi
-          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run monthly on the 1st at midnight UTC to test with latest pixi
+    - cron: '0 0 1 * *'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract minimum pixi version from pixi.toml
+        id: pixi-version
+        run: |
+          # Extract version from requires-pixi = ">=X.Y.Z"
+          VERSION=$(grep 'requires-pixi' pixi.toml | sed 's/.*>=\([0-9.]*\).*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Using minimum pixi version: $VERSION"
+
+      - name: Set up Pixi (minimum version)
+        if: github.event_name != 'schedule'
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          pixi-version: v${{ steps.pixi-version.outputs.version }}
+          log-level: v
+          cache: true
+
+      - name: Set up Pixi (latest version for scheduled builds)
+        if: github.event_name == 'schedule'
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          log-level: v
+          cache: true
+
+      - name: Build with Pixi
+        run: pixi -v install
+
+      - name: Run test
+        run: pixi run test
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract minimum pixi version from pixi.toml
+        id: pixi-version
+        run: |
+          VERSION=$(grep 'requires-pixi' pixi.toml | sed 's/.*>=\([0-9.]*\).*/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Using minimum pixi version: $VERSION"
+
+      - name: Set up Pixi (minimum version)
+        if: github.event_name != 'schedule'
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          pixi-version: v${{ steps.pixi-version.outputs.version }}
+          log-level: v
+          cache: true
+
+      - name: Set up Pixi (latest version for scheduled builds)
+        if: github.event_name == 'schedule'
+        uses: prefix-dev/setup-pixi@v0.9.1
+        with:
+          log-level: v
+          cache: true
+
+      - name: Build with Pixi
+        run: pixi -v install
+
+      - name: Run test with timeout (30s smoke test)
+        run: |
+          # Start the test in the background
+          pixi run test &
+          TEST_PID=$!
+
+          # Wait for 30 seconds
+          sleep 30
+
+          # Check if the process is still running (which means it's working fine)
+          if kill -0 $TEST_PID 2>/dev/null; then
+            echo "Test still running after 30s - smoke test passed!"
+            kill $TEST_PID 2>/dev/null || true
+            exit 0
+          else
+            # Process finished - check if it succeeded or failed
+            wait $TEST_PID
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "Test completed successfully within 30s"
+              exit 0
+            else
+              echo "Test failed with exit code $EXIT_CODE"
+              exit $EXIT_CODE
+            fi
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
+    branches: [master]
   schedule:
     # Run monthly on the 1st at midnight UTC to test with latest pixi
     - cron: '0 0 1 * *'
@@ -38,9 +40,6 @@ jobs:
           log-level: v
           cache: true
 
-      - name: Build with Pixi
-        run: pixi -v install
-
       - name: Run test
         run: pixi run test
 
@@ -72,9 +71,6 @@ jobs:
         with:
           log-level: v
           cache: true
-
-      - name: Build with Pixi
-        run: pixi -v install
 
       - name: Run test with timeout (30s smoke test)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,18 @@ on:
     - cron: '0 0 1 * *'
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-64
+            smoke-test: false
+          - os: macos-latest
+            platform: osx-arm64
+            smoke-test: true
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
@@ -40,50 +50,23 @@ jobs:
           log-level: v
           cache: true
 
-      - name: Run test
+      - name: Run test (full)
+        if: ${{ !matrix.smoke-test }}
         run: pixi run test
 
-  build-macos:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Extract minimum pixi version from pixi.toml
-        id: pixi-version
-        run: |
-          VERSION=$(grep 'requires-pixi' pixi.toml | sed 's/.*>=\([0-9.]*\).*/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Using minimum pixi version: $VERSION"
-
-      - name: Set up Pixi (minimum version)
-        if: github.event_name != 'schedule'
-        uses: prefix-dev/setup-pixi@v0.9.1
-        with:
-          pixi-version: v${{ steps.pixi-version.outputs.version }}
-          log-level: v
-          cache: true
-
-      - name: Set up Pixi (latest version for scheduled builds)
-        if: github.event_name == 'schedule'
-        uses: prefix-dev/setup-pixi@v0.9.1
-        with:
-          log-level: v
-          cache: true
-
-      - name: Run test with timeout (30s smoke test)
+      - name: Run test (2min timeout)
+        if: ${{ matrix.smoke-test }}
         run: |
           # Start the test in the background
           pixi run test &
           TEST_PID=$!
 
-          # Wait for 30 seconds
-          sleep 30
+          # Wait for 2 minutes
+          sleep 120
 
-          # Check if the process is still running (which means it's working fine)
+          # Check if the process is still running
           if kill -0 $TEST_PID 2>/dev/null; then
-            echo "Test still running after 30s - smoke test passed!"
+            echo "Test still running after 2 minutes - stopping"
             kill $TEST_PID 2>/dev/null || true
             exit 0
           else
@@ -91,7 +74,7 @@ jobs:
             wait $TEST_PID
             EXIT_CODE=$?
             if [ $EXIT_CODE -eq 0 ]; then
-              echo "Test completed successfully within 30s"
+              echo "Test completed successfully within 2 minutes"
               exit 0
             else
               echo "Test failed with exit code $EXIT_CODE"

--- a/GSM/CMakeLists.txt
+++ b/GSM/CMakeLists.txt
@@ -75,7 +75,11 @@ message("${BLAS_LIBRARIES} ${BLAS_LINKER_FLAGS}")
 
 find_package(BLAS REQUIRED)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${BLAS_LINKER_FLAGS}")
-target_include_directories(gsm PUBLIC "$ENV{MKLROOT}/include")
+
+# MKL include path (Linux only)
+if(DEFINED ENV{MKLROOT})
+    target_include_directories(gsm PUBLIC "$ENV{MKLROOT}/include")
+endif()
 
 FIND_PACKAGE( OpenMP REQUIRED)
 if(OPENMP_FOUND)

--- a/GSM/blas_compat.h
+++ b/GSM/blas_compat.h
@@ -1,0 +1,32 @@
+// BLAS/LAPACK compatibility header for cross-platform support
+// Abstracts differences between MKL (Linux) and OpenBLAS (macOS)
+
+#ifndef BLAS_COMPAT_H
+#define BLAS_COMPAT_H
+
+#ifdef __APPLE__
+// macOS with OpenBLAS/Accelerate
+#include <cblas.h>
+
+// Define MKL_INT as int for compatibility with existing code
+typedef int MKL_INT;
+
+// Declare LAPACK functions (Fortran interface)
+extern "C" {
+    void dgesvd_(char*, char*, int*, int*, double*, int*, double*, double*, int*,
+                 double*, int*, double*, int*, int*);
+    void dgetrf_(int*, int*, double*, int*, int*, int*);
+    void dgetri_(int*, double*, int*, int*, double*, int*, int*);
+    void dsyevx_(char*, char*, char*, int*, double*, int*, double*, double*,
+                 int*, int*, double*, int*, double*, double*, int*, double*,
+                 int*, int*, int*, int*);
+    void dsyevd_(char*, char*, int*, double*, int*, double*, double*, int*,
+                 int*, int*, int*);
+}
+
+#else
+// Linux with MKL
+#include <mkl.h>
+#endif
+
+#endif // BLAS_COMPAT_H

--- a/GSM/bmat.cpp
+++ b/GSM/bmat.cpp
@@ -1,8 +1,6 @@
 #include "icoord.h"
 #include "utils.h"
 #include "blas_compat.h"
-//#include "/export/apps/Intel/Compiler/11.1/075/mkl/include/mkl.h"
-//#include "/opt/acml5.3.1/gfortran64/include/acml.h"
 
 using namespace std;
 

--- a/GSM/bmat.cpp
+++ b/GSM/bmat.cpp
@@ -1,6 +1,6 @@
 #include "icoord.h"
 #include "utils.h"
-#include <mkl.h>
+#include "blas_compat.h"
 //#include "/export/apps/Intel/Compiler/11.1/075/mkl/include/mkl.h"
 //#include "/opt/acml5.3.1/gfortran64/include/acml.h"
 

--- a/GSM/utils.cpp
+++ b/GSM/utils.cpp
@@ -3,7 +3,7 @@
 #include "omp.h"
 //#include <Accelerate/Accelerate.h>
 //#include <vecLib/clapack.h>
-#include <mkl.h>
+#include "blas_compat.h"
 //#include "/export/apps/Intel/Compiler/11.1/075/mkl/include/mkl.h"
 //#include "/export/apps/Intel/Compiler/11.1/075/mkl/include/mkl_lapack.h"
 //#include "/opt/acml5.3.1/gfortran64/include/acml.h"

--- a/GSM/utils.cpp
+++ b/GSM/utils.cpp
@@ -5,13 +5,6 @@
 //#include <vecLib/clapack.h>
 #include "blas_compat.h"
 
-#define USE_ACML 0
-
-// extern "C" void dgesvd_(char*,char*,int*,int*,double*,int*,double*,double*,int*,double*,int*,double*,int*,int*);
-// extern "C" void dgetrf_(int*,int*,double*,int*,int*,int*);
-// extern "C" void dgetri_(int*,double*,int*,int*,double*,int*,int*);
-// extern "C" void dsyevx_(char*,char*,char*,int*,double*,int*,double*,double*,int*,int*,double*,int*,double*,double*,int*,double*,int*,int*,int*,int*);
-
 using namespace std;
 
 void trans(double* Bt, double* B, int m, int n) {
@@ -415,12 +408,6 @@ int SVD(double* A, double* V, double* eigen, int m, int n){
   MKL_INT mkl_m = (MKL_INT) m;
   MKL_INT mkl_n = (MKL_INT) n;
 
-#if USE_ACML
- //disabled this function
-  printf(" SVD not set up for ACML \n");
-  return -1;
-#endif
-
 #if 0
   for (int i=0;i<m;i++)
   for (int j=0;j<n;j++)
@@ -458,12 +445,10 @@ int SVD(double* A, double* V, double* eigen, int m, int n){
   char JOBU='A';
   char JOBVT='A';
 
-#if !USE_ACML
   dgesvd_(&JOBU, &JOBVT, &mkl_m, &mkl_n, B, &LDA, S, U, &mkl_m, Vt, &mkl_n, Work, &LenWork, &Info);
 
 //vs dgesdd (divide and conquer version)
 //  dgesdd_((char*)"A", &m, &n, A, &LDA, S, U, &m, Vt, &n, Work0, &LenWork, IWork, &Info);
-#endif
 
   if (Info!=0)
     printf(" after SVD, Info error is: %i \n",Info);
@@ -607,17 +592,11 @@ int Diagonalize(double* A, double* eigen, int size){
 
     MKL_INT Info = 0;
 
-#if USE_ACML
-   dsyevx(JobZ, Range, UpLo, N, A, LDA, VL,
-          VU, IL, IU, AbsTol, &NEValFound, EVal, EVec, LDA,
-          IFail, &Info);
-#else
 #if DSYEVX
     dsyevx_(&JobZ, &Range, &UpLo, &N, A, &LDA, &VL, &VU, &IL, &IU, &AbsTol,
            &NEValFound, EVal, EVec, &LDA, Work, &LenWork, IWork, IFail, &Info);
 #else
     dsyevd_(&JobZ, &UpLo, &N, A, &LDA, EVal, Work, &LenWork, IWork, &LenIWork, &Info);
-#endif
 #endif
 
 #if 0
@@ -683,14 +662,8 @@ int Diagonalize(double* A, double* eigenvecs, double* eigen, int size){
 
     MKL_INT Info = 0;
 
-#if USE_ACML
-   dsyevx(JobZ, Range, UpLo, N, A, LDA, VL,
-          VU, IL, IU, AbsTol, &NEValFound, EVal, EVec, LDA,
-          IFail, &Info);
-#else
     dsyevx_(&JobZ, &Range, &UpLo, &N, A, &LDA, &VL, &VU, &IL, &IU, &AbsTol,
            &NEValFound, EVal, EVec, &LDA, Work, &LenWork, IWork, IFail, &Info);
-#endif
 
 #if 0
     if (Info != 0 && KillJob) {

--- a/GSM/utils.cpp
+++ b/GSM/utils.cpp
@@ -4,9 +4,6 @@
 //#include <Accelerate/Accelerate.h>
 //#include <vecLib/clapack.h>
 #include "blas_compat.h"
-//#include "/export/apps/Intel/Compiler/11.1/075/mkl/include/mkl.h"
-//#include "/export/apps/Intel/Compiler/11.1/075/mkl/include/mkl_lapack.h"
-//#include "/opt/acml5.3.1/gfortran64/include/acml.h"
 
 #define USE_ACML 0
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,25 +8,29 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-21.1.8-h4922eb0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mopac-23.2.2-h8876d29_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: .
+        build: hb0f4dca_0
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-7_hc63b1ca_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-hf598326_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-7_ha522803_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.8-h4a912ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mopac-23.2.2-h1aae681_0.conda
+      - conda: .
+        build: h60d57d3_0
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
   build_number: 7
@@ -38,6 +42,25 @@ packages:
   license_family: BSD
   size: 8244
   timestamp: 1764092331208
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
+  md5: a44032f282e7d2acdeb1c240308052dd
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8325
+  timestamp: 1764092507920
+- conda: .
+  name: gsm
+  version: 0.1.0
+  build: h60d57d3_0
+  subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
+  depends:
+  - libcxx >=21
 - conda: .
   name: gsm
   version: 0.1.0
@@ -49,17 +72,6 @@ packages:
   - libstdcxx *
   - libstdcxx >=15
   - libgcc >=15
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
-  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
-  md5: 186a18e3ba246eccfc7cff00cd19a870
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 12728445
-  timestamp: 1767969922681
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
   build_number: 5
   sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
@@ -77,6 +89,32 @@ packages:
   license_family: BSD
   size: 18213
   timestamp: 1765818813880
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-7_hc63b1ca_netlib.conda
+  build_number: 7
+  sha256: fbaf96014d811ac744cc43d2edc7a1761bbc7d84871cfcca48cca40d49c25933
+  md5: 0222b4b0d294f6ac6542802236db4283
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - blas * netlib
+  track_features:
+  - blas_netlib
+  - blas_netlib_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 170730
+  timestamp: 1763442681272
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-hf598326_1.conda
+  sha256: 3a924cbce92b0dceb5d392036e692bac1e60ae90d85c7c78264c672a205c007b
+  md5: cd7367d0c0f49853f8f3560bfb4456ab
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 570705
+  timestamp: 1769754656112
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
   sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
   md5: 6d0363467e6ed84f11435eb309f2ff06
@@ -90,6 +128,18 @@ packages:
   license_family: GPL
   size: 1042798
   timestamp: 1765256792743
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_16.conda
+  sha256: 646c91dbc422fe92a5f8a3a5409c9aac66549f4ce8f8d1cab7c2aa5db789bb69
+  md5: 8b216bac0de7a9d60f3ddeba2515545c
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==15.2.0=*_16
+  - libgomp 15.2.0 16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 402197
+  timestamp: 1765258985740
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
   sha256: 8a7b01e1ee1c462ad243524d76099e7174ebdd94ff045fe3e9b1e58db196463b
   md5: 40d9b534410403c821ff64f00d0adc22
@@ -101,6 +151,17 @@ packages:
   license_family: GPL
   size: 27215
   timestamp: 1765256845586
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_16.conda
+  sha256: 68a6c1384d209f8654112c4c57c68c540540dd8e09e17dd1facf6cf3467798b5
+  md5: 11e09edf0dde4c288508501fe621bab4
+  depends:
+  - libgfortran5 15.2.0 hdae7583_16
+  constrains:
+  - libgfortran-ng ==15.2.0=*_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 138630
+  timestamp: 1765259217400
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
   sha256: d0e974ebc937c67ae37f07a28edace978e01dc0f44ee02f29ab8a16004b8148b
   md5: 39183d4e0c05609fd65f130633194e37
@@ -113,28 +174,17 @@ packages:
   license_family: GPL
   size: 2480559
   timestamp: 1765256819588
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
-  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
-  md5: 0ed3aa3e3e6bc85050d38881673a692f
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_16.conda
+  sha256: 9fb7f4ff219e3fb5decbd0ee90a950f4078c90a86f5d8d61ca608c913062f9b0
+  md5: 265a9d03461da24884ecc8eb58396d57
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libxml2
-  - libxml2-16 >=2.14.6
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2449916
-  timestamp: 1765103845133
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
-  md5: 915f5995e94f60e9a4826e0b0920ee88
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 790176
-  timestamp: 1754908768807
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 598291
+  timestamp: 1765258993165
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
   build_number: 5
   sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
@@ -149,17 +199,23 @@ packages:
   license_family: BSD
   size: 18200
   timestamp: 1765818857876
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
-  md5: c7c83eecbb72d88b940c249af56c8b17
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-7_ha522803_netlib.conda
+  build_number: 7
+  sha256: f87dd226ef356e630409d76989bf9f03635cc72588ff3a7c80d183308c716ce0
+  md5: ebd867fa4936b44381e532356a078c0f
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - xz 5.8.2.*
-  license: 0BSD
-  size: 113207
-  timestamp: 1768752626120
+  - __osx >=11.0
+  - libblas 3.11.0.*
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.2.0
+  track_features:
+  - blas_netlib
+  - blas_netlib_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2521103
+  timestamp: 1763442715553
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
   sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
   md5: be43915efc66345cccb3c310b6ed0374
@@ -186,49 +242,6 @@ packages:
   license_family: GPL
   size: 5856456
   timestamp: 1765256838573
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
-  sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
-  md5: 417955234eccd8f252b86a265ccdab7f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.1,<79.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libxml2-16 2.15.1 hca6bf5a_1
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 45402
-  timestamp: 1766327161688
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
-  sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
-  md5: 3fdd8d99683da9fe279c2f4cecd1e048
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.1,<79.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - libxml2 2.15.1
-  license: MIT
-  license_family: MIT
-  size: 555747
-  timestamp: 1766327145986
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - zlib 1.3.1 *_2
-  license: Zlib
-  license_family: Other
-  size: 60963
-  timestamp: 1727963148474
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-21.1.8-h4922eb0_0.conda
   sha256: a5a7ad16eecbe35cac63e529ea9c261bef4ccdd68cb1db247409f04529423989
   md5: f8640b709b37dc7758ddce45ea18d000
@@ -241,21 +254,18 @@ packages:
   license_family: APACHE
   size: 6127279
   timestamp: 1765964409311
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
-  sha256: 659d79976f06d2b796a0836414573a737a0856b05facfa77e5cc114081a8b3d4
-  md5: f121ddfc96e6a93a26d85906adf06208
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.8-h4a912ad_0.conda
+  sha256: 56bcd20a0a44ddd143b6ce605700fdf876bcf5c509adc50bf27e76673407a070
+  md5: 206ad2df1b5550526e386087bef543c7
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex * *_llvm
-  - _openmp_mutex >=4.5
-  - libgcc >=14
-  - libstdcxx >=14
-  - llvm-openmp >=21.1.8
-  - tbb >=2022.3.0
-  license: LicenseRef-IntelSimplifiedSoftwareOct2022
-  license_family: Proprietary
-  size: 125728406
-  timestamp: 1767634121080
+  - __osx >=11.0
+  constrains:
+  - openmp 21.1.8|21.1.8.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 285974
+  timestamp: 1765964756583
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mopac-23.2.2-h8876d29_0.conda
   sha256: 1843d22dad8329ae79a09c23171cad9323f67d833cc9de92d334fc4efd4c0181
   md5: eec3fa83e5913e28ce1ed4d2f71b9395
@@ -271,15 +281,19 @@ packages:
   license_family: APACHE
   size: 2096233
   timestamp: 1761751973490
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
-  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
-  md5: 8f7278ca5f7456a974992a8b34284737
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mopac-23.2.2-h1aae681_0.conda
+  sha256: 4f0a7705fc853f8c19f3ce10da040470d89569d495391d631747aecd77d9151b
+  md5: 09826a4f6c8f19bf746dbd6e3437fbc5
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libhwloc >=2.12.2,<2.12.3.0a0
-  - libstdcxx >=14
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libgfortran5 >=15.2.0
+  - liblapack >=3.9.0,<4.0a0
+  - llvm-openmp >=19.1.7
+  - llvm-openmp >=21.1.4
   license: Apache-2.0
   license_family: APACHE
-  size: 181329
-  timestamp: 1767886632911
+  size: 2124806
+  timestamp: 1761752436091

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,15 +8,24 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-21.1.8-h4922eb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mopac-23.2.2-h8876d29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: .
         build: hb0f4dca_0
       osx-arm64:
@@ -27,6 +36,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_16.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_16.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-7_ha522803_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.31-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.8-h4a912ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mopac-23.2.2-h1aae681_0.conda
       - conda: .
@@ -72,6 +82,17 @@ packages:
   - libstdcxx *
   - libstdcxx >=15
   - libgcc >=15
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
+  md5: 186a18e3ba246eccfc7cff00cd19a870
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 12728445
+  timestamp: 1767969922681
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
   build_number: 5
   sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
@@ -185,6 +206,28 @@ packages:
   license_family: GPL
   size: 598291
   timestamp: 1765258993165
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
+  md5: 0ed3aa3e3e6bc85050d38881673a692f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2449916
+  timestamp: 1765103845133
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  size: 790176
+  timestamp: 1754908768807
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
   build_number: 5
   sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
@@ -216,6 +259,17 @@ packages:
   license_family: BSD
   size: 2521103
   timestamp: 1763442715553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
+  md5: c7c83eecbb72d88b940c249af56c8b17
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.2.*
+  license: 0BSD
+  size: 113207
+  timestamp: 1768752626120
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
   sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
   md5: be43915efc66345cccb3c310b6ed0374
@@ -230,6 +284,20 @@ packages:
   license_family: BSD
   size: 5927939
   timestamp: 1763114673331
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.31-openmp_he657e61_0.conda
+  sha256: 974dffeec34686a8c973da6d0bd2511a8c82331348e3e0a830338a297332e9fa
+  md5: 97076546572b6561f9d4fcee15ba13a0
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.31,<0.3.32.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4305104
+  timestamp: 1768555339353
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
   sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
   md5: 68f68355000ec3f1d6f26ea13e8f525f
@@ -242,6 +310,49 @@ packages:
   license_family: GPL
   size: 5856456
   timestamp: 1765256838573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
+  sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
+  md5: 417955234eccd8f252b86a265ccdab7f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 hca6bf5a_1
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 45402
+  timestamp: 1766327161688
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+  sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
+  md5: 3fdd8d99683da9fe279c2f4cecd1e048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.1
+  license: MIT
+  license_family: MIT
+  size: 555747
+  timestamp: 1766327145986
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-21.1.8-h4922eb0_0.conda
   sha256: a5a7ad16eecbe35cac63e529ea9c261bef4ccdd68cb1db247409f04529423989
   md5: f8640b709b37dc7758ddce45ea18d000
@@ -266,6 +377,21 @@ packages:
   license_family: APACHE
   size: 285974
   timestamp: 1765964756583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
+  sha256: 659d79976f06d2b796a0836414573a737a0856b05facfa77e5cc114081a8b3d4
+  md5: f121ddfc96e6a93a26d85906adf06208
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvm-openmp >=21.1.8
+  - tbb >=2022.3.0
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 125728406
+  timestamp: 1767634121080
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mopac-23.2.2-h8876d29_0.conda
   sha256: 1843d22dad8329ae79a09c23171cad9323f67d833cc9de92d334fc4efd4c0181
   md5: eec3fa83e5913e28ce1ed4d2f71b9395
@@ -297,3 +423,15 @@ packages:
   license_family: APACHE
   size: 2124806
   timestamp: 1761752436091
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
+  md5: 8f7278ca5f7456a974992a8b34284737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  size: 181329
+  timestamp: 1767886632911

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["Zimmerman Group, Andreas Copan (pixi environment)"]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64"]
-requires-pixi = ">=0.50.2"
+requires-pixi = ">=0.60.0"
 preview = ["pixi-build"]
 
 [package]

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,3 +33,9 @@ openblas = "*"
 [dependencies]
 mopac = "*"
 gsm = {path = "."}
+
+[target.linux-64.dependencies]
+mkl = "*"
+
+[target.osx-arm64.dependencies]
+libopenblas = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["Zimmerman Group, Andreas Copan (pixi environment)"]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
-# requires-pixi = ">=0.50.2"
+requires-pixi = ">=0.50.2"
 preview = ["pixi-build"]
 
 [package]

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,7 +12,6 @@ version = "0.1.0"
 [package.build.backend]
 name = "pixi-build-cmake"
 version = ">=0.3.6,<=0.3.8"
-channels = ["https://prefix.dev/conda-forge"]
 
 [tasks]
 # gsm <N> -> initial000N.xyz

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 authors = ["Zimmerman Group, Andreas Copan (pixi environment)"]
 channels = ["conda-forge"]
-platforms = ["linux-64"]
+platforms = ["linux-64", "osx-arm64"]
 requires-pixi = ">=0.50.2"
 preview = ["pixi-build"]
 
@@ -22,11 +22,15 @@ test = { cmd = "gsm 1", cwd = "TEST/dielsAlder/mopac/de-gsm" }
 cmake = "*"
 
 [package.host-dependencies]
+
+[package.target.linux-64.host-dependencies]
 libstdcxx-ng = "*"
 mkl = "*"
 mkl-include = "*"
 
+[package.target.osx-arm64.host-dependencies]
+openblas = "*"
+
 [dependencies]
-mkl = "*"
 mopac = "*"
 gsm = {path = "."}


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI workflow that builds and tests molecularGSM on both Linux (linux-64) and macOS (osx-arm64).

### Changes
- **CI workflow** (`.github/workflows/ci.yml`): Matrix-based workflow that runs full tests on both platforms
- **macOS platform support**: Added `osx-arm64` to supported platforms in `pixi.toml`
- **BLAS compatibility layer** (`GSM/blas_compat.h`): Abstracts MKL (Linux) vs OpenBLAS (macOS) differences
- **Platform-specific dependencies**:
  - Linux: MKL for BLAS/LAPACK (`mkl`, `mkl-include`)
  - macOS: OpenBLAS (`openblas`, `libopenblas`) - MKL doesn't support ARM architecture
- **Pixi version requirement**: Bumped to `>=0.60.0` for pixi-build API v2 compatibility
- **Workflow optimizations**:
  - Consolidated Linux/macOS jobs using matrix strategy (54 lines vs original 101)
  - Scoped push/pull_request triggers to `master` branch to avoid duplicate CI runs
  - Monthly scheduled builds to test with latest pixi version
- **Code cleanup**: Removed obsolete ACML code and hardcoded BLAS library paths

### Files modified
- `.github/workflows/ci.yml` (new)
- `pixi.toml` - platforms, dependencies, requires-pixi
- `pixi.lock` - updated lock file
- `GSM/blas_compat.h` (new) - cross-platform BLAS/LAPACK header
- `GSM/bmat.cpp` - use blas_compat.h
- `GSM/utils.cpp` - use blas_compat.h, remove dead ACML code
- `GSM/CMakeLists.txt` - conditional MKLROOT include path

---

## ARM Mac / BLAS Compatibility Note

This PR uses OpenBLAS instead of MKL on macOS because Intel MKL doesn't have native ARM support. Apple Silicon M-series chips are ARM-based, so MKL would either fail or run through Rosetta 2 emulation. OpenBLAS has native ARM support and is the standard BLAS implementation for ARM systems.

Paul confirmed this approach is acceptable (discussed 2/3/26).

---

🤖 Generated with [Claude Code](https://claude.ai/code)