### PR TITLE
Bump pixi-build-cmake cap to 0.4.2 for pixi 0.71 (SlaterGPU#96)

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 
 [package.build.backend]
 name = "pixi-build-cmake"
-version = ">=0.3.6,<=0.3.8"
+version = ">=0.3.6,<=0.4.2"
 
 [tasks]
 # gsm <N> -> initial000N.xyz


### PR DESCRIPTION
Fixes the pixi 0.71 build break described in ZimmermanGroup/SlaterGPU#96 for this repo.

## Problem
pixi 0.71 negotiates **build-API version 5**. The pinned `pixi-build-cmake = ">=0.3.6,<=0.3.8"` only allows v4/v2 backends, so the dependency solve fails *before any compile*:

```
pixi-build-cmake >=0.3.6,<=0.3.8 cannot be installed ... pixi-build-api-version: no candidates
```

## Fix
Raise the **bounded** cap to the tested `0.4.2` (API v5). We keep an upper cap on purpose (backend updates have broken builds before — SlaterGPU#50, SlaterGPU#71); this just moves it to a known-good version. The range `>=0.3.6,<=0.4.2` spans both v4 and v5 backends, and `pixi-build-api-version` is a solver dependency, so each pixi version auto-selects a compatible backend.

## Verification (local, Perlmutter)
Negotiation verified against the shared backend channel:
- **pixi 0.71.0** → `pixi-build-cmake@0.4.2`, API v5 ✅ (was failing)
- **pixi 0.70.0** → `pixi-build-cmake@0.3.14`, API v4 ✅ (floor preserved)

`requires-pixi = ">=0.60.0"` unchanged. (molecularGSM is standalone — no SlaterGPU source dependency.)

## Coordinated change
Identical one-line bump across the four repos sharing this pin (SlaterGPU#96): SlaterGPU (#97), ZEST (#100), XCtera (#17), molecularGSM.